### PR TITLE
Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Tippse
 ======
-Tippse is a text editor.
+Tippse is a text and hex editor.
 
 1. [Download and unzip](https://github.com/wunderfeyd/tippse/archive/master.zip).
 2. Compile from source `./make.sh`
@@ -8,5 +8,5 @@ Tippse is a text editor.
 4. Do your work and use the command panel with <kbd>Ctrl</kbd>+<kbd>P</kbd>
 
 Additional information...
-* [Tippse help files](doc/index.md)
+* [Tippse documentation](doc/index.md)
 * [License](LICENSE.md)

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,104 +1,102 @@
-Tippse
-======
+Tippse documentation
+====================
 
 Tippse is a small text and hex editor. It's designed to have a simple interface and default hot key set based on the average editor in the wild, to handle huge files while maintaining a good working speed and to allow file and project based configuration.
 
-* Syntax
+## Syntax
 
-  tippse <--state|-s statefile> <files...>
+`tippse <--state|-s statefile> <files...>`
 
-  The files given at the command line are opened at startup. If `--state` or `-s` is mentioned then the editor will restore the documents and windows on load from the state file and save these things during exit to the same state file.
+The files given at the command line are opened at startup. If `--state` or `-s` is mentioned then the editor will restore the documents and windows on load from the state file and save these things during exit to the same state file.
 
-* Usage
+## Usage
 
-  * Basic use
+* Basic use
 
-    The editor is using a console device for display and renders the document to the whole console screen space. Navigate with the positioning/arrow keys, type your text. When ready hit CTRL+S to save all documents and exit with CTRL+Q. If other operations are needed lookup the commands with CTRL+P which opens a panel, with all possible commands and keyboard shortcuts.
+  The editor is using a console device for display and renders the document to the whole console screen space. Navigate with the positioning/arrow keys, type your text. When ready hit CTRL+S to save all documents and exit with CTRL+Q. If other operations are needed lookup the commands with CTRL+P which opens a panel, with all possible commands and keyboard shortcuts.
 
-  * Open a file
+* Open a file
 
-    CTRL+B activates the integrated file browser. Enter a target directory or file and the browser will jump to the specified location or open the file. Otherwise use the arrows keys to select a entry and ENTER to open the document. To filter a large file set type a part of the filename to filter for, it's updated automatically.
+  CTRL+B activates the integrated file browser. Enter a target directory or file and the browser will jump to the specified location or open the file. Otherwise use the arrows keys to select a entry and ENTER to open the document. To filter a large file set type a part of the filename to filter for, it's updated automatically.
 
-  * Navigating between open files
+* Navigating between open files
 
-    With CTRL+D all open documents and their status are displayed. Like the browser you can filter and select you document. The most recent document is displayed first. As an alternative CTRL+E switches back to the previous opened document.
+  With CTRL+D all open documents and their status are displayed. Like the browser you can filter and select you document. The most recent document is displayed first. As an alternative CTRL+E switches back to the previous opened document.
 
-  * Save file(s)
+* Save file(s)
 
-    CTRL+S is saving all modified files. If the editor can't save or has not enough information to save a file it will display a selection box.
+  CTRL+S is saving all modified files. If the editor can't save or has not enough information to save a file it will display a selection box.
 
-  * Quit
+* Quit
 
-    When using CTRL+Q the editor tries to quit. If documents unsaved or something else went wrong it will display a selection box.
+  When using CTRL+Q the editor tries to quit. If documents unsaved or something else went wrong it will display a selection box.
 
-  * Search
+* Search
 
-    Hit CTRL+F enter your phrase to search for and press ENTER. The editor will highlight the next found position or display an error message.
+  Hit CTRL+F enter your phrase to search for and press ENTER. The editor will highlight the next found position or display an error message.
 
-    To start or continue searching it's possible to use the F3 key for a forward search and SHIFT+F3 for a backwards search.
+  To start or continue searching it's possible to use the F3 key for a forward search and SHIFT+F3 for a backwards search.
 
-    To display the last file search use CTRL+SHIFT+F3. It's started with a second CTRL+SHIFT+F3.
+  To display the last file search use CTRL+SHIFT+F3. It's started with a second CTRL+SHIFT+F3.
 
-  * Replace
+* Replace
 
-    Hit CTRL+F enter your phrase to search for, hit CTRL+H enter the replacement text. Hit F7 to replace all findings. Use F6 to replace one after the other, manually. With SHIFT+F6 the process is searching backwards.
+  Hit CTRL+F enter your phrase to search for, hit CTRL+H enter the replacement text. Hit F7 to replace all findings. Use F6 to replace one after the other, manually. With SHIFT+F6 the process is searching backwards.
 
-  * Cut/Copy/Paste
+* Cut/Copy/Paste
 
-    The standard short cuts for cut (CTRL+X), copy (CTRL+C) and paste (CTRL+V) are configured by default.
+  The standard short cuts for cut (CTRL+X), copy (CTRL+C) and paste (CTRL+V) are configured by default.
 
-    *Hint* If you wish to use a shared clipboard in linux you can install xsel to copy between X11/desktop clipboard and Tippse. In MacOS pbcopy/pbpaste is used.
+  **Hint:** If you wish to use a shared clipboard in linux you can install xsel to copy between X11/desktop clipboard and Tippse. In MacOS pbcopy/pbpaste is used.
 
-  * Advanced use
+* Advanced use
 
-    There're many more operations Tippse can offer. CTRL+P opens the command panel. You can inspect the shortcuts, filter or start commands from here.
+  There're many more operations Tippse can offer. CTRL+P opens the command panel. You can inspect the shortcuts, filter or start commands from here.
 
-  * Search options
+* Search options
 
-    Select `searchcase...` in the command panel to switch between case sensitive or insensitive search. With `searchmode...` the algorithm can toggled between [regular expressions](regex.md) and normal text search.
+  Select `searchcase...` in the command panel to switch between case sensitive or insensitive search. With `searchmode...` the algorithm can toggled between [regular expressions](regex.md) and normal text search.
 
-  * Hex editor
+* Hex editor
 
-    With CTRL+U the document editor alternates between a hex editor and a text editor.
+  With CTRL+U the document editor alternates between a hex editor and a text editor.
 
-* Configuration
+## Configuration
 
-  The base configuration is loaded from (home)/.tippse/.tippse, and incrementally overwritten by all .tippse files found in the subpaths to the document file.
+The base configuration is loaded from `(home)/.tippse/.tippse`, and incrementally overwritten by all `.tippse` files found in the subpaths to the document file.
 
-  TODO (explain config structure, example from config.c)
+TODO: Explain config structure, example from `config.c`.
 
-* Tippse mental framework
+## Tippse mental framework
 
-  * No change policy
+* No change policy
 
-    Tippse tries hard to keep the original document structure intact. In fact it does only change document portions the user applied commands to.
+  Tippse tries hard to keep the original document structure intact. In fact it does only change document portions the user applied commands to.
 
-  * No convert policy
+* No convert policy
 
-    Unlike some other editors the file is not converted between an internal and the external encoding during load.
+  Unlike some other editors the file is not converted between an internal and the external encoding during load.
 
-  * Document detail auto detection
+* Document detail auto detection
 
-    The tabstop style and width, the line endings and the encoding is detected from the file. In the wild there're always files that are edge cases. If you find some, contact us. We would like to improve the auto detection.
+  The tabstop style and width, the line endings and the encoding is detected from the file. In the wild there're always files that are edge cases. If you find some, contact us. We would like to improve the auto detection.
 
-  * Document on disk
+* Document on disk
 
-    The document above a minimal size (at the moment 1 MiB) is not loaded into memory. The document stays on disk. This allows an instant load and dealing with huge files. Only document changes are kept in memory and applied during write back onto disk. This also means that the document is written twice to disk in case some read/write regions overlap. First a temporary file which is renamed back to the original for example.
+  The document above a minimal size (at the moment 1 MiB) is not loaded into memory. The document stays on disk. This allows an instant load and dealing with huge files. Only document changes are kept in memory and applied during write back onto disk. This also means that the document is written twice to disk in case some read/write regions overlap. First a temporary file which is renamed back to the original for example.
 
-  * View mask
+* View mask
 
-    When a document is being displayed the document is parsed according to its document details and binary data. The parsed data is used to build a data structure which hold anchors for document position and display parameters (such a line count). When a document position is seeked and not found the file is parsed until that point. Indicated by the "Locating" bar at the top.
+  When a document is being displayed the document is parsed according to its document details and binary data. The parsed data is used to build a data structure which hold anchors for document position and display parameters (such a line count). When a document position is seeked and not found the file is parsed until that point. Indicated by the "Locating" bar at the top.
 
-* License
+## License
 
-  The code is licensed under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode). With some stripped unicode data files by Unicode, Inc (http://unicode.org/copyright.html).
+The code is licensed under [CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/legalcode). With some stripped unicode data files by Unicode, Inc <http://unicode.org/copyright.html>. For details consult the [license file](../LICENSE.md).
 
-  For details consult the [license file](../LICENSE.md).
+## Contact
 
-* Contact
+We would like to see bug reports, suggestions, questions and anything else project related at <https://github.com/wunderfeyd/tippse>.
 
-  We would like to see bug reports, suggestions, questions and anything else project related at https://github.com/wunderfeyd/tippse .
+## Thank you
 
-* Thank you
-
-  We want to thank everyone. It does not matter if you have contributed to this project or never heard about it. In the end every scenario will improve this project or will teach us how to do it better.
+We want to thank everyone. It does not matter if you have contributed to this project or never heard about it. In the end every scenario will improve this project or will teach us how to do it better.

--- a/doc/regex.md
+++ b/doc/regex.md
@@ -1,67 +1,67 @@
-Regular expressions in Tippse
-=============================
+Tippse regular expressions
+==========================
 
-* Escaping
+## Escaping
 
-  Regular expressions command literals have to be different to usual literals. To allow both in the same text, the escape character `\` switches to the other form (literal or command). For example `\|` results in a `|` in the output instead of the alternative command `|`. To enter an arbitrary character/codepoint it's possible to use \xXX, \uXXXX and \UXXXXXXXX where X is the hexadecimal representation of the codepoint.
+Regular expressions command literals have to be different to usual literals. To allow both in the same text, the escape character `\` switches to the other form (literal or command). For example `\|` results in a `|` in the output instead of the alternative command `|`. To enter an arbitrary character/codepoint it's possible to use \xXX, \uXXXX and \UXXXXXXXX where X is the hexadecimal representation of the codepoint.
 
-* Alternatives
+## Alternatives
 
-  Alternatives are used in the form `abc|def` and matches `abc` or `def`.
+Alternatives are used in the form `abc|def` and matches `abc` or `def`.
 
-* Grouping
+## Grouping
 
-  Literals and/or other groups can be grouped together either to repeat with quantization modifiers or as backreferences in replacements. `(abc)+`
+Literals and/or other groups can be grouped together either to repeat with quantization modifiers or as backreferences in replacements. `(abc)+`
 
-* Sets
+## Sets
 
-  If one or more literals are allowed at the same position it possible to use a literal set in form of `[abc]`. It is possible to add ranges like `[A-Z]`, to invert the final set with `[^A-Z]` and/or use a character class `[^\w_]`. Please note that the `-` (minus sign) has to be escaped and is not allowed as stand alone at the end of the set unlike other implementations.
+If one or more literals are allowed at the same position it possible to use a literal set in form of `[abc]`. It is possible to add ranges like `[A-Z]`, to invert the final set with `[^A-Z]` and/or use a character class `[^\w_]`. Please note that the `-` (minus sign) has to be escaped and is not allowed as stand alone at the end of the set unlike other implementations.
 
-* Character classes
+## Character classes
 
-  Predefined sets are:
+Predefined sets are:
 
-  1. `\d` digits (all languages)
-  2. `\D` everything else than digits
-  3. `\w` letters (all languages)
-  4. `\W` everything else than letters
-  5. `\s` whitespace (all languages)
-  6. `\S` everything else than whitespace
+1. `\d` digits (all languages)
+2. `\D` everything else than digits
+3. `\w` letters (all languages)
+4. `\W` everything else than letters
+5. `\s` whitespace (all languages)
+6. `\S` everything else than whitespace
 
-* Quantization
+## Quantization
 
-  After a group or literal the number of repetitions are added if more or less than a single match is needed. Possible commands:
+After a group or literal the number of repetitions are added if more or less than a single match is needed. Possible commands:
 
-  1. `*` matches from 0 to infinite times
-  2. `+` matches from 1 to infinite times
-  3. `?` matches from 0 to 1 times
-  4. `{n}` matches exactly n times
-  5. `{n,}` matches at least n times
-  6. `{,m}` matches from 0 to m times
-  7. `{n,m}` matches from n to m times
+1. `*` matches from 0 to infinite times
+2. `+` matches from 1 to infinite times
+3. `?` matches from 0 to 1 times
+4. `{n}` matches exactly n times
+5. `{n,}` matches at least n times
+6. `{,m}` matches from 0 to m times
+7. `{n,m}` matches from n to m times
 
-  Example: `(abc){3}` would match `abcabcabc` and `(abc|def){2}` would match `abcabc`, `abcdef`, `defabc` or `defdef`.
+Example: `(abc){3}` would match `abcabcabc` and `(abc|def){2}` would match `abcabc`, `abcdef`, `defabc` or `defdef`.
 
-* Matching type
+## Matching type
 
-  After using a quantization modifier software search for the longest match longest match (greedy). To modify this behaviour use one of the following options:
+After using a quantization modifier software search for the longest match longest match (greedy). To modify this behaviour use one of the following options:
 
-  * Lazy matching
+* Lazy matching
 
-    When using `?` the shortest match that fulfills the criterias is used.
+  When using `?` the shortest match that fulfills the criterias is used.
 
-  * Possessive matching
+* Possessive matching
 
-    When using `+` the longest match of the group/literal is used. Unlike the greedy match type which also checks the rest of the expression.
+  When using `+` the longest match of the group/literal is used. Unlike the greedy match type which also checks the rest of the expression.
 
-* Anchors
+## Anchors
 
-  With `^` the search start with the next line start or file start. Whereas `$` checks for a line end or file end.
+With `^` the search start with the next line start or file start. Whereas `$` checks for a line end or file end.
 
-* Backreferences
+## Backreferences
 
-  Backreferences are allowed in replacements and during matching outside the referenced group. Use \1 to \9 for the group number. `(\S)123(\S)` with replacement `\1\2` on `abc123def` results in `abcdef`.
+Backreferences are allowed in replacements and during matching outside the referenced group. Use \1 to \9 for the group number. `(\S)123(\S)` with replacement `\1\2` on `abc123def` results in `abcdef`.
 
-* Notes
+## Notes
 
-  When using the "ignore case" option the literal sets are expanded with their uppercase/lowercase variants. If the transformation results in more than one codepoint/character everything is added. For example the german `ß` is expanded to `ss`.
+When using the "ignore case" option the literal sets are expanded with their uppercase/lowercase variants. If the transformation results in more than one codepoint/character everything is added. For example the german `ß` is expanded to `ss`.


### PR DESCRIPTION
While reviewing documentation noticed that it wasn't in Markdown format, this should fix it. 
In the documentation Tippse is described as "text and hex editor", have changed that in the README as well.